### PR TITLE
implement check-all-sat command (found in mathSAT5)

### DIFF
--- a/src/lib/smtlib_lexer.mll
+++ b/src/lib/smtlib_lexer.mll
@@ -100,6 +100,7 @@ rule token = parse
 | "echo" { ECHO }
 | "assert" { ASSERT }
 | "check-sat" { CHECKSAT }
+| "check-all-sat" { CHECKALLSAT }
 | "check-sat-assuming" { CHECKSATASSUMING }
 | "check-entailment" { CHECKENTAILMENT }
 | "get-assertions" { GETASSERT }

--- a/src/lib/smtlib_parser.mly
+++ b/src/lib/smtlib_parser.mly
@@ -21,7 +21,7 @@
 %token EOF AS EXISTS FORALL  LET LP POP PUSH ECHO RP UNDERSCORE PAR  PATTERN
 MATCH EXCLIMATIONPT
 
-%token ASSERT CHECKSAT EXIT RESET RESETASSERTIONS CHECKSATASSUMING
+%token ASSERT CHECKSAT CHECKALLSAT EXIT RESET RESETASSERTIONS CHECKSATASSUMING
  CHECKENTAILMENT
 DECLAREFUN DECLARESORT DECLARECONST  DECLAREDATATYPES DECLAREDATATYPE
 DEFINEFUN DEFINEFUNREC DEFINEFUNSREC DEFINESORT
@@ -268,6 +268,8 @@ command:
         {mk_data ($startpos,$endpos) (Cmd_CheckSatAssum $4) }
     | LP CHECKENTAILMENT assert_dec RP
         {mk_data ($startpos,$endpos) (Cmd_CheckEntailment $3) }
+    | LP CHECKALLSAT list(symbol) RP
+        {mk_data ($startpos,$endpos) (Cmd_CheckAllSat $3) }
     | LP DECLARECONST symbol const_dec RP
         {mk_data ($startpos,$endpos) (Cmd_DeclareConst ($3,$4)) }
     | LP DECLAREDATATYPE symbol datatype_dec RP

--- a/src/lib/smtlib_printer.ml
+++ b/src/lib/smtlib_printer.ml
@@ -154,6 +154,11 @@ let print_command c =
     printf "(check-sat-assuming %s)\n%!"
       (print_list print_pro_lit prop_lit_list)
 
+  | Cmd_CheckAllSat tl ->
+      let tl = List.map (fun symb -> symb.c) tl in
+      let s = String.concat " " tl in
+      printf "(check-all-sat %s)\n%!" s
+
   | Cmd_DeclareConst(symbol,(pars,sort)) ->
     printf "(declare-const %s %s)\n%!" symbol.c (print_const_dec pars sort)
 

--- a/src/lib/smtlib_syntax.ml
+++ b/src/lib/smtlib_syntax.ml
@@ -160,6 +160,7 @@ and constructor_dec = symbol * selector_dec list
 type command_aux =
   | Cmd_Assert of (symbol list * term)
   | Cmd_CheckSat
+  | Cmd_CheckAllSat of symbol list
   | Cmd_CheckSatAssum of prop_literal list
   | Cmd_CheckEntailment of (symbol list * term)
   | Cmd_DeclareConst of symbol * (symbol list * sort)

--- a/src/lib/smtlib_typing.ml
+++ b/src/lib/smtlib_typing.ml
@@ -234,6 +234,15 @@ let type_command (env,locals) c =
       (Smtlib_ty.new_type Smtlib_ty.TBool) (get_term (env,locals) pars t) t.p;
     env
 
+  | Cmd_CheckAllSat tl ->
+      let pars = [] in
+      let idl = [] in
+      List.iter (fun symb ->
+          let ty = find_par_ty (env,locals) symb pars idl in
+          Smtlib_ty.unify (Smtlib_ty.new_type Smtlib_ty.TBool) ty symb.p
+        ) tl;
+      env
+
   | Cmd_Minimize t | Cmd_Maximize t ->
       let t' = get_term (env,locals) [] t in
       begin


### PR DESCRIPTION
implement check-all-sat command: a list of propositional variables is given to filter the model. If the list is empty, no filtering is done